### PR TITLE
Allow multiple modes to be provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Then, add it to your `gulpfile.js`:
 var gitmodified = require("gulp-gitmodified");
 
 var files = gulp.src("./src/*.ext")
-	.pipe(gitmodified('modified'))
+  .pipe(gitmodified("modified"));
 
-files.on('data', function (file) {
+files.on("data", function (file) {
   console.log("Modified file:", file);
 });
 ```
@@ -30,18 +30,20 @@ files.on('data', function (file) {
 
 ### gitmodified(statusMode)
 
+For `statusMode`, you can pass a single string value or an array of string values.
+
 `gulp-gitmodified` extends the vinyl file format gulp uses to have a method
-for checking if file is deleted. isDeleted is true if checking for deleted
+for checking if file is deleted. `isDeleted` is true if checking for deleted
 files (see below), and false otherwise.
 
 #### statusMode
-Type: `String`  
+
+Type: `String` || `Array`
 Default: "modified"
 
 What status mode to look for. From git documentation:
 
 ```
-' ' = unmodified
 M = modified
 A = added
 D = deleted
@@ -54,12 +56,12 @@ U = updated but unmerged
 
 (and more if in short format (e.g. AM), see Short Format on [git status man page](https://www.kernel.org/pub/software/scm/git/docs/git-status.html))
 
-Can also use string representation. Examples:
+#### Examples
 
 ```javascript
 // All added files
-gulp.src('./**/*')
-    .pipe(gitmodified('added'))
+gulp.src("./**/*")
+    .pipe(gitmodified("added"))
 ```
 
 ```javascript
@@ -69,12 +71,18 @@ gulp.src('./**/*')
 ```
 
 ```javascript
+// All added and modified files
+gulp.src("./**/*")
+    .pipe(gitmodified(["added", "modified"]))
+```
+
+```javascript
 // All deleted files.
-gulp.src('./**/*')
-    .pipe(gitmodified('deleted'))
-		.on('data', function (file) {
-			console.log(file.isDeleted()); //=> true
-		})
+gulp.src("./**/*")
+    .pipe(gitmodified("deleted"))
+    .on("data", function (file) {
+      console.log(file.isDeleted()); //=> true
+    });
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ module.exports = function (modes) {
   var files = null,
       regexTest,
       modeMapping = {
-    unmodified: ' ',
     modified: 'M',
     added: 'A',
     deleted: 'D',

--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
 var through = require('through2'),
-  find = require('lodash.find'),
+  _ = require('lodash'),
   gutil = require('gulp-util'),
   git = require('./lib/git'),
   File = require('vinyl');
 
-module.exports = function (mode) {
+module.exports = function (modes) {
   'use strict';
 
   var files = null,
       regexTest,
       modeMapping = {
-    unmodified: '\\s',
+    unmodified: ' ',
     modified: 'M',
     added: 'A',
     deleted: 'D',
@@ -21,17 +21,25 @@ module.exports = function (mode) {
     ignored: '!!'
   };
 
-  if (mode && !!modeMapping[mode.trim().toLowerCase()]) {
-    mode = modeMapping[mode.trim().toLowerCase()];
-  }
-  mode = (mode || 'M').replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
-  regexTest = new RegExp('^'+mode+'\\s', 'i');
+  if (!_.isArray(modes)) modes = [modes];
+
+  modes = modes.reduce(function(acc, mode) {
+    var mappedMode;
+    if (!_.isString(mode)) return acc;
+    mappedMode = modeMapping[mode.trim().toLowerCase()] || mode;
+    return acc.concat(mappedMode.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'));
+  }, []);
+
+  if (_.isEmpty(modes)) modes = ['M'];
+
+  regexTest = new RegExp('^('+modes.join('|')+')\\s', 'i');
 
   var gitmodified = function (file, enc, callback) {
     var stream = this;
 
     var checkStatus = function () {
-      var isIn = !!find(files, function (line) {
+      var isIn = !!_.find(files, function (fileLine) {
+        var line = fileLine.path;
         if (line.substring(line.length, line.length - 1)) {
           return file.path.indexOf(line.substring(0, line.length - 1)) !== -1;
         }
@@ -55,12 +63,11 @@ module.exports = function (mode) {
       }
       files = statusFiles;
 
-      if (mode === 'D') {
-        // Deleted files. Make into vinyl files
-        files.map(makeVinylFile).forEach(function (file) {
-          stream.push(file);
-        });
-      }
+      // Deleted files. Make into vinyl files
+      files.forEach(function(file) {
+        if (file.mode !== 'D') return;
+        stream.push(makeVinylFile(file.path));
+      });
 
       checkStatus();
     });

--- a/lib/git.js
+++ b/lib/git.js
@@ -28,10 +28,10 @@ Git.prototype.getStatusByMatcher = function (matcher, cb) {
       }
       // partly inspired and taken from NPM version module
       var lines = stdout.trim().split("\n").filter(function (line) {
-        return line.trim() && matcher.test(line);
+        return line.trim() && matcher.test(line.trim());
       }).map(function (line) {
         return {
-          mode: matcher.exec(line)[0].trim(),
+          mode: matcher.exec(line.trim())[0].trim(),
           path: line.trim().replace(matcher, "").trim()
         };
       });

--- a/lib/git.js
+++ b/lib/git.js
@@ -28,9 +28,12 @@ Git.prototype.getStatusByMatcher = function (matcher, cb) {
       }
       // partly inspired and taken from NPM version module
       var lines = stdout.trim().split("\n").filter(function (line) {
-        return line.trim() && matcher.test(line.trim());
+        return line.trim() && matcher.test(line);
       }).map(function (line) {
-        return line.trim().replace(matcher, "").trim();
+        return {
+          mode: matcher.exec(line)[0].trim(),
+          path: line.trim().replace(matcher, "").trim()
+        };
       });
       return cb(null, lines);
     });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "through2": "*",
-    "lodash.find": "~2.4.1",
+    "lodash": "~2.4.1",
     "which": "~1.0.5",
     "gulp-util": "~2.2.12",
     "vinyl": "^0.4.3"

--- a/test/git.js
+++ b/test/git.js
@@ -87,8 +87,8 @@ describe("gulp-gitmodified", function () {
     git.getStatusByMatcher(new RegExp("^(M)\\s", "i"), function (err, data) {
       should.not.exist(err);
       data.length.should.equal(2);
-      data[0].should.eql({ mode: 'M', path: 'index.js' });
-      data[1].should.eql({ mode: 'M', path: 'bar.js' });
+      data[0].should.eql({ mode: "M", path: "index.js" });
+      data[1].should.eql({ mode: "M", path: "bar.js" });
       done();
     });
   });
@@ -103,8 +103,8 @@ describe("gulp-gitmodified", function () {
     git.getStatusByMatcher(new RegExp("^(A|D)\\s", "i"), function (err, data) {
       should.not.exist(err);
       data.length.should.equal(2);
-      data[0].should.eql({ mode: 'D', path: 'foo.js' });
-      data[1].should.eql({ mode: 'A', path: 'baz.js' });
+      data[0].should.eql({ mode: "D", path: "foo.js" });
+      data[1].should.eql({ mode: "A", path: "baz.js" });
       done();
     });
   });
@@ -119,9 +119,9 @@ describe("gulp-gitmodified", function () {
     git.getStatusByMatcher(new RegExp("^(C|!!|\\?\\?)\\s", "i"), function (err, data) {
       should.not.exist(err);
       data.length.should.equal(3);
-      data[0].should.eql({ mode: 'C', path: 'index.js' });
-      data[1].should.eql({ mode: '??', path: 'foo.js' });
-      data[2].should.eql({ mode: '!!', path: 'baz.js' });
+      data[0].should.eql({ mode: "C", path: "index.js" });
+      data[1].should.eql({ mode: "??", path: "foo.js" });
+      data[2].should.eql({ mode: "!!", path: "baz.js" });
       done();
     });
   });

--- a/test/git.js
+++ b/test/git.js
@@ -20,7 +20,7 @@ describe("gulp-gitmodified", function () {
       app.should.equal("git");
       cb(null, "");
     };
-    git.getStatusByMatcher(new RegExp("^( )\\s", "i"), function (err) {
+    git.getStatusByMatcher(new RegExp("^(M)\\s", "i"), function (err) {
       should(err).equal(null);
       fnCalls.should.equal(2);
       done();
@@ -35,7 +35,7 @@ describe("gulp-gitmodified", function () {
     git.exec = function (app, args, extra, cb) {
       cb(null, "");
     };
-    git.getStatusByMatcher(new RegExp("^( )\\s", "i"), function (err) {
+    git.getStatusByMatcher(new RegExp("^(M)\\s", "i"), function (err) {
       should(err.message).equal("git not found on your system.");
       done();
     });
@@ -114,13 +114,13 @@ describe("gulp-gitmodified", function () {
       cb();
     };
     git.exec = function (app, args, extra, cb) {
-      cb(null, "M index.js\n?? foo.js\n  bar.js\n!! baz.js");
+      cb(null, "C index.js\n?? foo.js\n  bar.js\n!! baz.js");
     };
-    git.getStatusByMatcher(new RegExp("^( |!!|\\?\\?)\\s", "i"), function (err, data) {
+    git.getStatusByMatcher(new RegExp("^(C|!!|\\?\\?)\\s", "i"), function (err, data) {
       should.not.exist(err);
       data.length.should.equal(3);
-      data[0].should.eql({ mode: '??', path: 'foo.js' });
-      data[1].should.eql({ mode: '', path: 'bar.js' });
+      data[0].should.eql({ mode: 'C', path: 'index.js' });
+      data[1].should.eql({ mode: '??', path: 'foo.js' });
       data[2].should.eql({ mode: '!!', path: 'baz.js' });
       done();
     });

--- a/test/main.js
+++ b/test/main.js
@@ -74,7 +74,7 @@ describe("gulp-gitmodified", function () {
 
   describe("map mode from named string to short hand", function () {
     it("should map for 'modified'", function (done) {
-      git.getStatusByMatcher = function (tester, cb) {
+      git.getStatusByMatcher = function (tester) {
         tester.toString().should.equal("/^(M)\\s/i");
         done();
       };
@@ -83,7 +83,7 @@ describe("gulp-gitmodified", function () {
     });
 
     it("should map for 'added'", function (done) {
-      git.getStatusByMatcher = function (tester, cb) {
+      git.getStatusByMatcher = function (tester) {
         tester.toString().should.equal("/^(A)\\s/i");
         done();
       };
@@ -92,7 +92,7 @@ describe("gulp-gitmodified", function () {
     });
 
     it("should map for 'deleted'", function (done) {
-      git.getStatusByMatcher = function (tester, cb) {
+      git.getStatusByMatcher = function (tester) {
         tester.toString().should.equal("/^(D)\\s/i");
         done();
       };
@@ -101,7 +101,7 @@ describe("gulp-gitmodified", function () {
     });
 
     it("should map for 'renamed'", function (done) {
-      git.getStatusByMatcher = function (tester, cb) {
+      git.getStatusByMatcher = function (tester) {
         tester.toString().should.equal("/^(R)\\s/i");
         done();
       };
@@ -110,7 +110,7 @@ describe("gulp-gitmodified", function () {
     });
 
     it("should map for 'copied'", function (done) {
-      git.getStatusByMatcher = function (tester, cb) {
+      git.getStatusByMatcher = function (tester) {
         tester.toString().should.equal("/^(C)\\s/i");
         done();
       };
@@ -119,7 +119,7 @@ describe("gulp-gitmodified", function () {
     });
 
     it("should map for 'updated'", function (done) {
-      git.getStatusByMatcher = function (tester, cb) {
+      git.getStatusByMatcher = function (tester) {
         tester.toString().should.equal("/^(U)\\s/i");
         done();
       };
@@ -128,7 +128,7 @@ describe("gulp-gitmodified", function () {
     });
 
     it("should map for 'untracked'", function (done) {
-      git.getStatusByMatcher = function (tester, cb) {
+      git.getStatusByMatcher = function (tester) {
         tester.toString().should.equal("/^(\\?\\?)\\s/i");
         done();
       };
@@ -137,7 +137,7 @@ describe("gulp-gitmodified", function () {
     });
 
     it("should map for 'ignored'", function (done) {
-      git.getStatusByMatcher = function (tester, cb) {
+      git.getStatusByMatcher = function (tester) {
         tester.toString().should.equal("/^(!!)\\s/i");
         done();
       };
@@ -146,7 +146,7 @@ describe("gulp-gitmodified", function () {
     });
 
     it("should map multiple modes from named strings to multiple short hand", function (done) {
-      git.getStatusByMatcher = function (tester, cb) {
+      git.getStatusByMatcher = function (tester) {
         tester.toString().should.equal("/^(A|D|\\?\\?)\\s/i");
         done();
       };

--- a/test/main.js
+++ b/test/main.js
@@ -73,15 +73,6 @@ describe("gulp-gitmodified", function () {
   });
 
   describe("map mode from named string to short hand", function () {
-    it("should map for 'unmodified'", function (done) {
-      git.getStatusByMatcher = function (tester, cb) {
-        tester.toString().should.equal("/^( )\\s/i");
-        done();
-      };
-      var instream = gulp.src(filePath);
-      instream.pipe(gitmodified("unmodified"));
-    });
-
     it("should map for 'modified'", function (done) {
       git.getStatusByMatcher = function (tester, cb) {
         tester.toString().should.equal("/^(M)\\s/i");
@@ -156,11 +147,11 @@ describe("gulp-gitmodified", function () {
 
     it("should map multiple modes from named strings to multiple short hand", function (done) {
       git.getStatusByMatcher = function (tester, cb) {
-        tester.toString().should.equal("/^(A|D| |\\?\\?)\\s/i");
+        tester.toString().should.equal("/^(A|D|\\?\\?)\\s/i");
         done();
       };
       var instream = gulp.src(filePath);
-      instream.pipe(gitmodified(["added", "deleted", "unmodified", "untracked"]));
+      instream.pipe(gitmodified(["added", "deleted", "untracked"]));
     });
   });
 


### PR DESCRIPTION
Add support for array of modes to be passed in.

```javascript
// All added files
gulp.src("./**/*")
    .pipe(gitmodified("added"))
```

```javascript
// All added and modified files
gulp.src("./**/*")
    .pipe(gitmodified(["added", "modified"]))
```

---

#### Notes

 - Removed `unmodified` - this isn't a state which is returned from `git status`
 - Update readme for new parameter type for `statusMode` and remove `unmodified` from list of modes.