### PR TITLE
Add JSHint script and update source to pass linting

### DIFF
--- a/examples/gulpfile.js
+++ b/examples/gulpfile.js
@@ -1,19 +1,22 @@
+"use strict";
+
 var gulp = require("gulp"),
-    through = require('through2'),
+    through = require("through2"),
     gitmodified = require("../");
 
 gulp.task("foo", function () {
-  var data = gulp.src(["../**/*", "!../node_modules/**"])
+  gulp.src(["../**/*", "!../node_modules/**"])
     .pipe(through.obj(function (file, enc, cb) {
       this.push(file);
       return cb();
     }))
     .pipe(gitmodified())
-    .on('error', function (err) {
+    .on("error", function (err) {
       console.log(err);
     })
     .pipe(through.obj(function (file, enc, cb) {
       console.log("Modified: ", file.relative);
       this.push(file);
-      return cb()    }));
+      return cb();
+    }));
 });

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,7 +1,9 @@
+"use strict";
+
 var exec = require("child_process").execFile,
   which = require("which");
 
-var gitApp = 'git',
+var gitApp = "git",
     gitExtra = {env: process.env};
 
 var Git = function () { };
@@ -18,11 +20,11 @@ Git.prototype.getStatusByMatcher = function (matcher, cb) {
   var that = this;
   that.which(gitApp, function (err) {
     if (err) {
-      return cb(new Error('git not found on your system.'))
+      return cb(new Error("git not found on your system."));
     }
-    that.exec(gitApp, [ "status", "--porcelain" ], gitExtra, function (err, stdout, stderr) {
+    that.exec(gitApp, [ "status", "--porcelain" ], gitExtra, function (err, stdout) {
       if (err) {
-        return cb(new Error('Could not get git status --porcelain'));
+        return cb(new Error("Could not get git status --porcelain"));
       }
       // partly inspired and taken from NPM version module
       var lines = stdout.trim().split("\n").filter(function (line) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "url": "git://github.com/mikaelbr/gulp-gitmodified.git"
   },
   "scripts": {
-    "test": "mocha -R spec"
+    "test": "mocha -R spec",
+    "lint": "jshint **/*.js"
   },
   "dependencies": {
     "through2": "*",
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "gulp": "~3.3.4",
+    "jshint": "~2.8.0",
     "mocha": "*",
     "should": "~2.1.0"
   },
@@ -38,9 +40,5 @@
     "node": ">=0.8.0",
     "npm": ">=1.2.10"
   },
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ]
+  "license": "MIT"
 }

--- a/test/git.js
+++ b/test/git.js
@@ -52,7 +52,7 @@ describe("gulp-gitmodified", function () {
       should.not.exist(err);
       should.exist(data);
       should.exist(data[0]);
-      data[0].should.equal('index.js');
+      data[0].should.equal("index.js");
       done();
     });
   });

--- a/test/main.js
+++ b/test/main.js
@@ -26,7 +26,7 @@ describe("gulp-gitmodified", function () {
   });
 
   it("should call git library with a tester", function (done) {
-    git.getStatusByMatcher = function (tester, cb) {
+    git.getStatusByMatcher = function (tester) {
       should.exist(tester);
       done();
     };
@@ -35,7 +35,7 @@ describe("gulp-gitmodified", function () {
   });
 
   it("should default to modified mode", function (done) {
-    git.getStatusByMatcher = function (tester, cb) {
+    git.getStatusByMatcher = function (tester) {
       tester.toString().should.equal("/^M\\s/i");
       done();
     };
@@ -44,7 +44,7 @@ describe("gulp-gitmodified", function () {
   });
 
   it("should map mode from named string to short hand", function (done) {
-    git.getStatusByMatcher = function (tester, cb) {
+    git.getStatusByMatcher = function (tester) {
       tester.toString().should.equal("/^M\\s/i");
       done();
     };
@@ -53,7 +53,7 @@ describe("gulp-gitmodified", function () {
   });
 
   it("should map deleted mode from named string to short hand", function (done) {
-    git.getStatusByMatcher = function (tester, cb) {
+    git.getStatusByMatcher = function (tester) {
       tester.toString().should.equal("/^D\\s/i");
       done();
     };
@@ -68,7 +68,7 @@ describe("gulp-gitmodified", function () {
     var instream = gulp.src(filePath);
     instream
       .pipe(gitmodified("modified"))
-      .pipe(through.obj(function(file, enc, cb) {
+      .pipe(through.obj(function(file) {
         should.exist(file);
         should.exist(file.path);
         should.exist(file.contents);
@@ -83,8 +83,8 @@ describe("gulp-gitmodified", function () {
     };
     var instream = gulp.src(filePath);
     instream
-      .pipe(gitmodified('D'))
-      .pipe(through.obj(function(file, enc, cb) {
+      .pipe(gitmodified("D"))
+      .pipe(through.obj(function(file) {
         should.exist(file);
         should.exist(file.isDeleted());
         should.not.exist(file.contents);
@@ -97,10 +97,9 @@ describe("gulp-gitmodified", function () {
       return cb(new Error("new error"));
     };
     var instream = gulp.src(filePath);
-    var outstream = gitmodified();
     instream
       .pipe(gitmodified())
-      .on('error', function (err) {
+      .on("error", function (err) {
         should.exist(err);
         err.message.should.equal("new error");
         done();
@@ -112,10 +111,9 @@ describe("gulp-gitmodified", function () {
       return cb(new Error("new error"));
     };
     var instream = gulp.src(filePath);
-    var outstream = gitmodified();
     instream
       .pipe(gitmodified())
-      .on('error', function (err) {
+      .on("error", function (err) {
         should.exist(err.plugin);
         err.plugin.should.equal("gulp-gitmodified");
         done();
@@ -128,10 +126,9 @@ describe("gulp-gitmodified", function () {
       cb(null, []);
     };
     var instream = gulp.src(filePath);
-    var outstream = gitmodified();
     instream
       .pipe(gitmodified("deleted"))
-      .pipe(through.obj(function(file, enc, cb) {
+      .pipe(through.obj(function() {
         ++numFiles;
         done();
       }, function (callback) {
@@ -141,7 +138,7 @@ describe("gulp-gitmodified", function () {
       }));
   });
 
-  it('should handle streamed files', function (done) {
+  it("should handle streamed files", function (done) {
     var streamedFile = new gutil.File({
       path: "test/fixtures/a.txt",
       cwd: "test/",
@@ -153,7 +150,7 @@ describe("gulp-gitmodified", function () {
       cb(null, ["a.txt"]);
     };
     var outstream = gitmodified();
-    outstream.on('data', function(file) {
+    outstream.on("data", function(file) {
       should.exist(file);
       should.exist(file.path);
       should.exist(file.contents);
@@ -166,7 +163,7 @@ describe("gulp-gitmodified", function () {
     outstream.write(streamedFile);
   });
 
-  it('should handle folders', function (done) {
+  it("should handle folders", function (done) {
     git.getStatusByMatcher = function (tester, cb) {
       cb(null, ["fixtures/"]);
     };
@@ -174,10 +171,10 @@ describe("gulp-gitmodified", function () {
     var instream = gulp.src(join(__dirname, "./fixtures"));
     var outstream = gitmodified();
 
-    outstream.on('data', function(file) {
+    outstream.on("data", function(file) {
       should.exist(file);
       should.exist(file.path);
-      file.relative.should.equal('fixtures');
+      file.relative.should.equal("fixtures");
       should.exist(file.isNull());
       done();
     });


### PR DESCRIPTION
Run linting with `npm run lint`. Uses JSHint to lint against the existing `.jshintrc` file.