### PR TITLE
incorrect work with file paths in windows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 root = true
 
 [*]
-indent_style = spaces
+indent_style = space
 indent_size = 2
 end_of_line = lf
 charset = utf-8

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var through = require('through2'),
   find = require('lodash.find'),
   gutil = require('gulp-util'),
   git = require('./lib/git'),
+  path = require('path'),
   File = require('vinyl');
 
 module.exports = function (modes) {
@@ -38,7 +39,7 @@ module.exports = function (modes) {
 
     var checkStatus = function () {
       var isIn = !!find(files, function (fileLine) {
-        var line = fileLine.path;
+        var line = path.normalize(fileLine.path);
         if (line.substring(line.length, line.length - 1)) {
           return file.path.indexOf(line.substring(0, line.length - 1)) !== -1;
         }


### PR DESCRIPTION
The arg `file` contains windows-styled path but paths returned from git represent in unix-style. So `.indexOf` checking does not work correct. I fixed it.