### PR TITLE
Add targetBranch option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 temp/
 npm-debug.log
+\.idea/

--- a/.jshintrc
+++ b/.jshintrc
@@ -10,11 +10,11 @@
     "latedef": true,
     "newcap": true,
     "noarg": true,
-    "quotmark": "double",
+    "quotmark": "single",
     "regexp": true,
     "undef": true,
     "unused": true,
-    "strict": true,
+    "strict": false,
     "trailing": true,
     "smarttabs": true,
     "white": true

--- a/README.md
+++ b/README.md
@@ -44,11 +44,16 @@ different directory than your where your repo resides.
 
 `stagedOnly` can be used to process only staged files.
 
+`targetBranch` can be used to get diff between current branch and targetBranch. 
+Actually `git diff --name-status targetBranch` will be executed.  
+It can't be used together with `stagedOnly`.
+
 ```
 // Options can be the following:
 {
   gitCwd: String,
   stagedOnly: Boolean,
+  targetBranch: String
   modes: statusMode
 }
 ```
@@ -93,6 +98,15 @@ gulp.src('./**/*')
 // All added and modified files
 gulp.src('./**/*')
     .pipe(gitmodified(['added', 'modified']))
+```
+
+```javascript
+// All added files on this branch
+gulp.src('./**/*')
+    .pipe(gitmodified({ 
+      modes: ['added', 'modified'],
+      targetBranch: 'origin/master'
+    }))
 ```
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function (modes) {
 
     const checkStatus = () => {
       const isIn = !!files.find((fileLine) => {
-        const line = path.normalize(fileLine.path);
+        const line = path.normalize(fileLine.path).replaceAll(/^\"|\"$/g, '');;
         if (line.substring(line.length, line.length - 1)) {
           return file.path.indexOf(line.substring(0, line.length - 1)) !== -1;
         }

--- a/index.js
+++ b/index.js
@@ -1,52 +1,80 @@
-var through = require('through2'),
-  find = require('lodash.find'),
-  PluginError = require('plugin-error'),
-  git = require('./lib/git'),
-  path = require('path'),
-  File = require('vinyl');
+const through = require('through2');
+const PluginError = require('plugin-error');
+const path = require('path');
+const File = require('vinyl');
+
+const git = require('./lib/git');
+
+const ModeMapping = {
+  modified: 'M',
+  added: 'A',
+  deleted: 'D',
+  renamed: 'R',
+  copied: 'C',
+  updated: 'U',
+  untracked: '??',
+  ignored: '!!',
+};
+
+function setDeleted(file, isDeleted) {
+  file.isDeleted = () => {
+    return !!isDeleted;
+  };
+}
+
+function makeVinylFile(path) {
+  const file = new File({
+    path: path,
+    contents: null,
+  });
+  setDeleted(file, true);
+  return file;
+}
 
 module.exports = function (modes) {
-  'use strict';
-  var options = {
+  let defaultOptions = {
     stagedOnly: false,
+    targetBranch: undefined,
+    gitCwd: undefined,
+    modes: ['M'],
   };
 
-  var files = null,
-      regexTest,
-      modeMapping = {
-    modified: 'M',
-    added: 'A',
-    deleted: 'D',
-    renamed: 'R',
-    copied: 'C',
-    updated: 'U',
-    untracked: '??',
-    ignored: '!!'
-  };
+  let files;
+  let regexTest;
+  let options = defaultOptions;
 
   if (typeof modes === 'object' && (!!modes.modes || !!modes.gitCwd)) {
     options = modes;
     modes = modes.modes || [];
   }
-  if (!Array.isArray(modes)) modes = [modes];
+  if (!Array.isArray(modes)) {
+    modes = [modes];
+  }
 
-  modes = modes.reduce(function(acc, mode) {
-    var mappedMode;
-    if (typeof mode !== 'string') return acc;
-    mappedMode = modeMapping[mode.trim().toLowerCase()] || mode;
+  if (options.stagedOnly && options.targetBranch) {
+    throw new PluginError('gulp-gitmodified', 'stageOnly and targetBranch can\'t be used together');
+  }
+
+  modes = modes.reduce((acc, mode) => {
+    if (typeof mode !== 'string') {
+      return acc;
+    }
+    const mappedMode = ModeMapping[mode.trim().toLowerCase()] || mode;
     return acc.concat(mappedMode.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'));
   }, []);
 
-  if (!modes.length) modes = ['M'];
+  if (!modes.length) {
+    modes = defaultOptions.modes;
+  }
 
-  regexTest = new RegExp('^('+modes.join('|')+')\\s', 'i');
+  regexTest = new RegExp('^(' + modes.join('|') + ')\\s', 'i');
 
-  var gitmodified = function (file, enc, callback) {
-    var stream = this;
+  const gitmodified = function (file, enc, callback) {
+    const stream = this;
 
-    var checkStatus = function () {
-      var isIn = !!find(files, function (fileLine) {
-        var line = path.normalize(fileLine.path);
+    const checkStatus = () => {
+      const isIn = !!files.find((fileLine) => {
+        const line = path.normalize(fileLine.path);
         if (line.substring(line.length, line.length - 1)) {
           return file.path.indexOf(line.substring(0, line.length - 1)) !== -1;
         }
@@ -63,7 +91,7 @@ module.exports = function (modes) {
     if (!!files) {
       return checkStatus();
     }
-    git.getStatusByMatcher(regexTest, options.gitCwd, options.stagedOnly, function (err, statusFiles) {
+    git.getStatusByMatcher(regexTest, options.gitCwd, options, (err, statusFiles) => {
       if (err) {
         stream.emit('error', new PluginError('gulp-gitmodified', err));
         return callback();
@@ -71,8 +99,10 @@ module.exports = function (modes) {
       files = statusFiles;
 
       // Deleted files. Make into vinyl files
-      files.forEach(function(file) {
-        if (file.mode !== 'D') return;
+      files.forEach(function (file) {
+        if (file.mode !== 'D') {
+          return;
+        }
         stream.push(makeVinylFile(file.path));
       });
 
@@ -81,20 +111,7 @@ module.exports = function (modes) {
   };
 
   return through.obj(gitmodified, function (callback) {
-    files = null;
+    files = undefined;
     return callback();
   });
 };
-
-function makeVinylFile (path) {
-  var file = new File({
-    path: path,
-    contents: null
-  });
-  setDeleted(file, true);
-  return file;
-}
-
-function setDeleted (file, isDeleted) {
-  file.isDeleted = function () { return !!isDeleted; };
-}

--- a/index.js
+++ b/index.js
@@ -43,14 +43,13 @@ module.exports = function (modes) {
   let regexTest;
   let options = defaultOptions;
 
-  if (typeof modes === 'object' && (!!modes.modes || !!modes.gitCwd)) {
+  if (typeof modes === 'object' && !Array.isArray(modes)) {
     options = modes;
     modes = modes.modes || [];
   }
   if (!Array.isArray(modes)) {
     modes = [modes];
   }
-
   if (options.stagedOnly && options.targetBranch) {
     throw new PluginError('gulp-gitmodified', 'stageOnly and targetBranch can\'t be used together');
   }

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,59 +1,61 @@
-'use strict';
+const exec = require('child_process').execFile;
+const which = require('which');
 
-var exec = require('child_process').execFile,
-  which = require('which');
+const gitApp = 'git';
+const gitExtra = { env: process.env };
 
-var gitApp = 'git',
-    gitExtra = {env: process.env};
-
-var Git = function () { };
-
-Git.prototype.exec = function (app, args, extra, cb) {
-  return exec(app, args, extra, cb);
-};
-
-Git.prototype.which = function (app, cb) {
-  return which(app, cb);
-};
-
-Git.prototype.getStatusByMatcher = function (matcher, baseDir, stagedOnly, cb) {
-  var that = this;
-  if (typeof baseDir === 'function') {
-    cb = baseDir;
-    baseDir = void 0;
-  }
-  var gitExtraOptions = gitExtra;
-  if (baseDir) {
-    gitExtraOptions = {
-      env: gitExtra.env,
-      cwd: baseDir
-    };
+class Git {
+  // used for tests
+  exec(app, args, extra, cb) {
+    return exec(app, args, extra, cb);
   }
 
-  that.which(gitApp, function (err) {
-    if (err) {
-      return cb(new Error('git not found on your system.'));
+  // used for tests
+  which(app, cb) {
+    return which(app, cb);
+  }
+
+  getStatusByMatcher(matcher, baseDir, { stagedOnly, targetBranch } = {}, cb = baseDir) {
+    if (typeof baseDir === 'function') {
+      baseDir = undefined;
     }
-    that.exec(gitApp, [ 'status', '--porcelain' ], gitExtraOptions, function (err, stdout) {
+    let gitExtraOptions = gitExtra;
+    if (baseDir) {
+      gitExtraOptions = {
+        env: gitExtra.env,
+        cwd: baseDir,
+      };
+    }
+
+    this.which(gitApp, (err) => {
       if (err) {
-        return cb(new Error('Could not get git status --porcelain'));
+        return cb(new Error('git not found on your system.'));
       }
-      // partly inspired and taken from NPM version module
-      var lines = stdout.split('\n').filter(function (line) {
-        if (!stagedOnly) {
-          // staged files doesn't have space in front
-          line = line.trim();
+
+      let gitArgs = ['status', '--porcelain'];
+      if (targetBranch) {
+        gitArgs = ['diff', '--name-status', targetBranch];
+      }
+
+      this.exec(gitApp, gitArgs, gitExtraOptions, (err, stdout) => {
+        if (err) {
+          return cb(new Error(`Could not execute git ${gitArgs.join(' ')}`));
         }
-        return line && matcher.test(line);
-      }).map(function (line) {
-        return {
+        // partly inspired and taken from NPM version module
+        const lines = stdout.split('\n').filter((line) => {
+          if (!stagedOnly) {
+            // staged files doesn't have space in front
+            line = line.trim();
+          }
+          return line && matcher.test(line);
+        }).map((line) => ({
           mode: matcher.exec(line.trim())[0].trim(),
-          path: line.trim().replace(matcher, '').trim()
-        };
+          path: line.trim().replace(matcher, '').trim(),
+        }));
+        return cb(null, lines);
       });
-      return cb(null, lines);
     });
-  });
-};
+  }
+}
 
 module.exports = new Git();

--- a/lib/git.js
+++ b/lib/git.js
@@ -32,9 +32,10 @@ class Git {
         return cb(new Error('git not found on your system.'));
       }
 
-      let gitArgs = ['status', '--porcelain'];
+      const configArgs = ['-c', 'core.quotepath=false'];
+      let gitArgs = [...configArgs, 'status', '--porcelain'];
       if (targetBranch) {
-        gitArgs = ['diff', '--name-status', targetBranch];
+        gitArgs = [...configArgs, 'diff', '--name-status', targetBranch];
       }
 
       this.exec(gitApp, gitArgs, gitExtraOptions, (err, stdout) => {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "lint": "jshint **/*.js"
   },
   "dependencies": {
-    "lodash.find": "^4.6.0",
     "plugin-error": "^1.0.1",
     "through2": "^2.0.0",
     "vinyl": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-gitmodified",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A plugin for Gulp to get an object stream of modified files on git.",
   "keywords": [
     "gulpplugin",

--- a/test/main.js
+++ b/test/main.js
@@ -1,20 +1,18 @@
 /*global describe, it*/
-'use strict';
-
-var should = require('should'),
-  through = require('through2'),
-  fs = require('fs'),
-  join = require('path').join,
-  git = require('../lib/git');
+const should = require('should');
+const through = require('through2');
+const fs = require('fs');
+const File = require('vinyl');
+const { join } = require('path');
+const git = require('../lib/git');
 
 require('mocha');
 
-var filePath = join(__dirname, './fixtures/*.txt'),
-    expectedFile = join(__dirname, './fixtures/a.txt');
+const filePath = join(__dirname, './fixtures/*.txt');
+const expectedFile = join(__dirname, './fixtures/a.txt');
 
-var gutil = require('gulp-util'),
-  gulp = require('gulp'),
-  gitmodified = require('../');
+const gulp = require('gulp');
+const gitmodified = require('../');
 
 describe('gulp-gitmodified', function () {
 
@@ -23,6 +21,20 @@ describe('gulp-gitmodified', function () {
     should.exist(stream.on);
     should.exist(stream.write);
     done();
+  });
+
+  it('should give error if stagedOnly used together with targetBranch', () => {
+    let error;
+    try {
+      gitmodified({
+        targetBranch: 'origin/master',
+        stagedOnly: true,
+      });
+    } catch (e) {
+      error = e;
+    }
+    should.exist(error && error.message);
+    error.message.should.equal('stageOnly and targetBranch can\'t be used together');
   });
 
   it('should call git library with a tester', function (done) {
@@ -274,7 +286,7 @@ describe('gulp-gitmodified', function () {
   });
 
   it('should handle streamed files', function (done) {
-    var streamedFile = new gutil.File({
+    var streamedFile = new File({
       path: 'test/fixtures/a.txt',
       cwd: 'test/',
       base: 'test/fixtures/',

--- a/test/main.js
+++ b/test/main.js
@@ -71,7 +71,7 @@ describe('gulp-gitmodified', function () {
       instream.pipe(gitmodified('foo'));
     });
 
-    it('should allow override of git root', function (done, baseDir) {
+    it('should allow override of git root', function (done) {
       var expected = 'myBaseDir';
       git.getStatusByMatcher = function (tester, actual) {
         actual.should.equal(expected);
@@ -85,7 +85,7 @@ describe('gulp-gitmodified', function () {
       }));
     });
 
-    it('should default to modified if only git cwd is passed', function (done, baseDir) {
+    it('should default to modified if only git cwd is passed', function (done) {
       var expected = 'myBaseDir';
       git.getStatusByMatcher = function (tester, actual) {
         actual.should.equal(expected);
@@ -98,7 +98,7 @@ describe('gulp-gitmodified', function () {
       }));
     });
 
-    it('should allow override of git root and modes array', function (done, baseDir) {
+    it('should allow override of git root and modes array', function (done) {
       var expected = 'myBaseDir';
       git.getStatusByMatcher = function (tester, actual) {
         actual.should.equal(expected);
@@ -197,11 +197,7 @@ describe('gulp-gitmodified', function () {
   });
 
   it('should return modified files', function (done) {
-    git.getStatusByMatcher = function (tester, baseDir, stagedOnly, cb) {
-      if (typeof baseDir === 'function') {
-        cb = baseDir;
-        baseDir = void 0;
-      }
+    git.getStatusByMatcher = function (tester, baseDir, { stagedOnly, targetBranch } = {}, cb = baseDir) {
       cb(null, [{ path: 'a.txt', mode: 'M' }]);
     };
     var instream = gulp.src(filePath);
@@ -217,11 +213,7 @@ describe('gulp-gitmodified', function () {
   });
 
   it('should return deleted files', function (done) {
-    git.getStatusByMatcher = function (tester, baseDir, stagedOnly, cb) {
-      if (typeof baseDir === 'function') {
-        cb = baseDir;
-        baseDir = void 0;
-      }
+    git.getStatusByMatcher = function (tester, baseDir, { stagedOnly, targetBranch } = {}, cb = baseDir) {
       cb(null, [{ path: 'a.txt', mode: 'D' }]);
     };
     var instream = gulp.src(filePath);
@@ -236,11 +228,7 @@ describe('gulp-gitmodified', function () {
   });
 
   it('should throw error when git returns error', function (done) {
-    git.getStatusByMatcher = function (tester, baseDir, stagedOnly, cb) {
-      if (typeof baseDir === 'function') {
-        cb = baseDir;
-        baseDir = void 0;
-      }
+    git.getStatusByMatcher = function (tester, baseDir, { stagedOnly, targetBranch } = {}, cb = baseDir) {
       return cb(new Error('new error'));
     };
     var instream = gulp.src(filePath);
@@ -254,11 +242,7 @@ describe('gulp-gitmodified', function () {
   });
 
   it('should throw gulp specific error', function (done) {
-    git.getStatusByMatcher = function (tester, baseDir, stagedOnly, cb) {
-      if (typeof baseDir === 'function') {
-        cb = baseDir;
-        baseDir = void 0;
-      }
+    git.getStatusByMatcher = function (tester, baseDir, { stagedOnly, targetBranch } = {}, cb = baseDir) {
       return cb(new Error('new error'));
     };
     var instream = gulp.src(filePath);
@@ -273,11 +257,7 @@ describe('gulp-gitmodified', function () {
 
   it('should pass on no files when no status is returned', function (done) {
     var numFiles = 0;
-    git.getStatusByMatcher = function (tester, baseDir, stagedOnly, cb) {
-      if (typeof baseDir === 'function') {
-        cb = baseDir;
-        baseDir = void 0;
-      }
+    git.getStatusByMatcher = function (tester, baseDir, { stagedOnly, targetBranch } = {}, cb = baseDir) {
       cb(null, []);
     };
     var instream = gulp.src(filePath);
@@ -301,11 +281,7 @@ describe('gulp-gitmodified', function () {
       contents: fs.createReadStream(join(__dirname, '/fixtures/a.txt'))
     });
 
-    git.getStatusByMatcher = function (tester, baseDir, stagedOnly, cb) {
-      if (typeof baseDir === 'function') {
-        cb = baseDir;
-        baseDir = void 0;
-      }
+    git.getStatusByMatcher = function (tester, baseDir, { stagedOnly, targetBranch } = {}, cb = baseDir) {
       cb(null, [{ path: 'a.txt', mode: 'M' }]);
     };
     var outstream = gitmodified();
@@ -323,11 +299,7 @@ describe('gulp-gitmodified', function () {
   });
 
   it('should handle folders', function (done) {
-    git.getStatusByMatcher = function (tester, baseDir, stagedOnly, cb) {
-      if (typeof baseDir === 'function') {
-        cb = baseDir;
-        baseDir = void 0;
-      }
+    git.getStatusByMatcher = function (tester, baseDir, { stagedOnly, targetBranch } = {}, cb = baseDir) {
       cb(null, [{ path: 'fixtures/', mode: 'M' }]);
     };
 


### PR DESCRIPTION
Add new option `targetBranch`:

> `targetBranch` can be used to get diff between current branch and targetBranch. 
> Actually `git diff --name-status targetBranch` will be executed.  
> It can't be used together with `stagedOnly`.

For example it is possible now to get all files which were created on this branch and process them.

Also I've updated code to modern ecma

- replace var with let/const
- replace prototype with class
- remove gutil from tests
- remove lodash.find dependency